### PR TITLE
[3.0-preview] Add a link to the old README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,7 @@ If running Windows you will need to set the following environment variables:
 - LAUNCHPAD_CHROME
 
 Read More here [daffl/launchpad](https://github.com/daffl/launchpad#environment-variables-impacting-local-browsers-detection)
+
+---
+
+Looking for our older PSK2 Polycast or migration blog post? See [the previous README](https://github.com/Polymer/polymer-starter-kit/blob/v3.2.1/README.md).


### PR DESCRIPTION
This lets users find the older Polycast video and migration blog post. Fixes #1099.